### PR TITLE
Feature/Add a scoped AMD loader implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement a scoped AMD loader on top of SystemJS
 - Project's bootstrap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "prettier-plugin-svelte": "^3.4.0",
                 "prettier-plugin-tailwindcss": "^0.6.14",
                 "svelte": "^5.38.2",
+                "systemjs": "^6.15.1",
                 "terser": "^5.43.1",
                 "typescript": "~5.9.2",
                 "typescript-eslint": "^8.40.0",
@@ -35,6 +36,9 @@
             },
             "engines": {
                 "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "systemjs": "^6.15.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2735,9 +2739,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.2.tgz",
-            "integrity": "sha512-kx7GHSOBiiIQ+DDgMP6YMtYkb/3Usm2nUYblNEM9P+/OfkuP7OjfoDlq/DCe1OU0GsREUa0rNAxZmzxgO6+jWg==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5227,6 +5231,13 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/systemjs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.15.1.tgz",
+            "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "prettier-plugin-svelte": "^3.4.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "svelte": "^5.38.2",
+        "systemjs": "^6.15.1",
         "terser": "^5.43.1",
         "typescript": "~5.9.2",
         "typescript-eslint": "^8.40.0",
@@ -81,6 +82,8 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.2.4"
     },
-    "peerDependencies": {},
+    "peerDependencies": {
+        "systemjs": "^6.15.1"
+    },
     "dependencies": {}
 }

--- a/public/samples/bundle.js
+++ b/public/samples/bundle.js
@@ -1,0 +1,17 @@
+define('external', [], function () {
+    return function external() {
+        return 'external';
+    };
+});
+define('resource', [], function () {
+    return function resource() {
+        return 'resource';
+    };
+});
+define('internal', ['external', 'resource'], function (external, resource) {
+    return {
+        compose(message) {
+            return `${message} from compose with ${external()} and ${resource()}`;
+        }
+    };
+});

--- a/public/samples/error.js
+++ b/public/samples/error.js
@@ -1,0 +1,3 @@
+define(() => {
+    throw new TypeError('Cannot read properties of undefined');
+});

--- a/public/samples/exports.js
+++ b/public/samples/exports.js
@@ -1,0 +1,5 @@
+define(function (require, exports, module) {
+    exports['foo'] = 'bar';
+    exports['require'] = require;
+    exports['module'] = module;
+});

--- a/public/samples/external.js
+++ b/public/samples/external.js
@@ -1,0 +1,5 @@
+define(function () {
+    return function external() {
+        return 'external';
+    };
+});

--- a/public/samples/internal.js
+++ b/public/samples/internal.js
@@ -1,0 +1,7 @@
+define(['external'], function (external) {
+    return {
+        compose(message) {
+            return `${message} from compose with ${external()}`;
+        }
+    };
+});

--- a/public/samples/invalid.js
+++ b/public/samples/invalid.js
@@ -1,0 +1,1 @@
+define('invalid');

--- a/public/samples/resource.js
+++ b/public/samples/resource.js
@@ -1,0 +1,3 @@
+define({
+    foo: 'bar'
+});

--- a/src/lib/amd-loader.ts
+++ b/src/lib/amd-loader.ts
@@ -1,0 +1,317 @@
+import type { AMD, ESM, SystemJS } from 'lib/systemjs.d.ts';
+
+// Dynamic module loader - must be imported before any other SystemJS module
+import 'systemjs/dist/system.js';
+// Full named define support - https://github.com/systemjs/systemjs/blob/main/docs/errors.md#W6
+import 'systemjs/dist/extras/named-register.js';
+
+/**
+ * Flow control for module imports. This ensures that when using multiple loaders,
+ * the loading process completes before calling the next load.
+ * This is needed because the global `define` function is overridden during loading.
+ */
+let importFlow = Promise.resolve();
+
+/**
+ * A utility for loading AMD modules and defining resources in a scoped context using [SystemJS](https://github.com/systemjs/systemjs).
+ *
+ * Each AMDLoader instance has its own module registry. If multiple loaders are created,
+ * they will use their own context so that same-named resources don't conflict.
+ *
+ * **Note:** the global `define` function is overridden each time a load is performed. To prevent
+ * conflict when using multiple loaders, a flow control mechanism is employed to ensure the loading
+ * process is completed before calling the next load.
+ * @example
+ * import { AMDLoader } from 'pci-loader';
+ * loader = new AMDLoader();
+ *
+ * // Pre-define a shared resource from an already loaded module, or an existing resource
+ * loader.define('myResource', {
+ *     // resource definition
+ * });
+ *
+ * // Map the resource to an external module path
+ * loader.define('myResource', 'path/to/resource');
+ *
+ * // Load the module and use the resources
+ * loader.load('path/to/myModule').then(exports => {
+ *     // Use the module exports
+ * });
+ *
+ * // A module previously defined can also be loaded
+ * loader.load('myResource').then(exports => {
+ *     // Use the module exports
+ * });
+ */
+export class AMDLoader {
+    #loader: SystemJS.Instance;
+    #importMap: SystemJS.ImportMap;
+    #define: AMD.Define;
+
+    constructor() {
+        this.#loader = new System.constructor();
+        this.#importMap = {
+            imports: {},
+            scopes: {}
+        };
+
+        this.#define = (
+            nameOrDepsOrResource: string | string[] | object | AMD.ResourceFactory,
+            depsOrFactory?: string[] | AMD.ResourceFactory,
+            factory?: AMD.ResourceFactory
+        ) => {
+            const [name, amdRegister] = extractRegistrationContext(nameOrDepsOrResource, depsOrFactory, factory);
+            if (name) {
+                this.#loader.registerRegistry[name] = amdRegister;
+                this.#loader.register(name, amdRegister[0], amdRegister[1]);
+            } else {
+                this.#loader.register(amdRegister[0], amdRegister[1]);
+            }
+        };
+        this.#define.amd = {};
+    }
+
+    /**
+     * Defines a resource in the AMD context.
+     * The resource may be a preloaded module or a mapping to a different location.
+     * @param name - The name of the resource.
+     * @param module - An URI string or the resource object.
+     * @example
+     * import { AMDLoader } from 'pci-loader';
+     * loader = new AMDLoader();
+     *
+     * // Pre-define a shared resource from an already loaded module, or an existing resource
+     * loader.define('myResource', {
+     *     // resource definition
+     * });
+     *
+     * // Map the resource to an external module path
+     * loader.define('myResource', 'path/to/resource');
+     */
+    define(name: string, module: string | ESM.Module, multiple: boolean = false): void {
+        if (typeof module == 'string') {
+            this.#importMap.imports[name] = module;
+        } else {
+            // use the `app:*` scheme for internal resources
+            // https://github.com/systemjs/systemjs/blob/6.15.1/docs/api.md#systemsetid-module---module
+            const uri = `app:${name}`;
+            this.#importMap.imports[name] = uri;
+            if (multiple || module[Symbol.toStringTag] === 'Module') {
+                this.#loader.set(uri, module);
+            } else {
+                this.#loader.set(uri, {
+                    default: module,
+                    __useDefault: true
+                });
+            }
+        }
+    }
+
+    /**
+     * Loads a scoped AMD module or bundle, and returns a promise that resolves with the module exports.
+     * It temporarily overrides the global define function, ensuring only the declared module's
+     * dependencies are available during loading.
+     * If you need external resources, consider defining them upfront, using `loader.define()`.
+     * @param modulePath - The path to the module.
+     * @returns A promise that resolves with the module exports.
+     * @example
+     * import { AMDLoader } from 'pci-loader';
+     * loader = new AMDLoader();
+     *
+     * // Load the module and use the resources
+     * loader.load('path/to/myModule').then(exports => {
+     *     // Use the module exports
+     * });
+     *
+     * // A module previously defined can also be loaded
+     * loader.load('myResource').then(exports => {
+     *     // Use the module exports
+     * });
+     */
+    async load(modulePath: string): Promise<unknown> {
+        return new Promise((resolve, reject) => {
+            const uncaughtError = (e: ErrorEvent) => {
+                // Only catch errors coming either from SystemJS or the loaded module
+                if (e.message?.includes('SystemJS Error') || e.error?.stack?.includes(modulePath)) {
+                    e.preventDefault();
+                    reject(e.error);
+                }
+            };
+
+            importFlow = importFlow.then(() => {
+                try {
+                    // The importMap needs to be redefined on each load.
+                    // This map is globally managed by SystemJS, and other loaders may modify it.
+                    this.#loader.addImportMap(this.#importMap);
+
+                    // Override the global define function.
+                    // This is needed to control the scope.
+                    const define = globalThis.define;
+                    globalThis.define = this.#define;
+                    window.addEventListener('error', uncaughtError);
+
+                    return this.#loader
+                        .import(modulePath)
+                        .then((module: ESM.Module | unknown) => {
+                            resolve(extractESM(module as ESM.Module));
+                        })
+                        .catch(reject)
+                        .finally(() => {
+                            globalThis.define = define;
+                            window.removeEventListener('error', uncaughtError);
+                        });
+                } catch (error) {
+                    return reject(error);
+                }
+            });
+        });
+    }
+}
+
+// AMD support extracted and refactored from 'systemjs/dist/extras/amd.js'
+// <[[[
+
+/**
+ * Generate an error message for SystemJS errors.
+ * @param errCode - The error code.
+ * @param msg - The error message.
+ * @returns The formatted error message.
+ */
+function errMsg(errCode: string | number, msg: string): string {
+    return `${msg} (SystemJS Error#${errCode} https://github.com/systemjs/systemjs/blob/main/docs/errors.md#${errCode})`;
+}
+
+/**
+ * Throw an error for unsupported AMD require calls.
+ */
+function unsupportedRequire(): never {
+    throw Error(errMsg(5, 'AMD require not supported.'));
+}
+
+/**
+ * Extract the exports from an ESM (ECMAScript Module).
+ * @param module - The SystemJS module to extract from.
+ * @returns The exports of the module.
+ */
+function extractESM(module: ESM.Module): ESM.Exports {
+    return module?.__useDefault ? module?.default : module;
+}
+
+/**
+ * Get the setter function for a specific dependency module.
+ * @param idx - The index of the dependency module.
+ * @param depModules - The array of dependency modules.
+ * @returns The setter function for the dependency module.
+ */
+function getSetter(idx: number, depModules: AMD.ModuleExport[]): SystemJS.ModuleSetter {
+    return (module: ESM.Module) => (depModules[idx] = extractESM(module));
+}
+
+/**
+ * Create an AMD module registration.
+ * @param amdDefineDeps - The AMD module dependencies.
+ * @param amdDefineExec - The AMD module execution function.
+ * @returns The SystemJS module registration.
+ */
+function createAMDRegister(amdDefineDeps: string[], amdDefineExec: AMD.ResourceFactory): SystemJS.ModuleRegistration {
+    const amdExec: AMD.ResourceFactory = amdDefineExec;
+    const exports: ESM.Exports = {};
+    const module: ESM.ModuleExport = { exports: exports };
+    const depModules: AMD.ModuleExport[] = [];
+    const setters: SystemJS.ModuleSetter[] = [];
+
+    let splice = 0;
+    for (let i = 0; i < amdDefineDeps.length; i++) {
+        const id = amdDefineDeps[i];
+        const index = setters.length;
+
+        if (id === 'require') {
+            depModules[i] = unsupportedRequire;
+            splice++;
+        } else if (id === 'module') {
+            depModules[i] = module;
+            splice++;
+        } else if (id === 'exports') {
+            depModules[i] = exports;
+            splice++;
+        } else {
+            setters.push(getSetter(i, depModules));
+        }
+
+        if (splice) {
+            amdDefineDeps[index] = id;
+        }
+    }
+
+    if (splice) {
+        amdDefineDeps.length -= splice;
+    }
+
+    return [
+        amdDefineDeps,
+        (_export: SystemJS.ExportSignature, _context: ESM.ModuleContext): SystemJS.ModuleDeclaration => {
+            _export({ default: exports, __useDefault: true });
+            return {
+                setters: setters,
+                execute() {
+                    module.uri = _context.meta.url;
+                    const amdResult: ESM.Exports = amdExec.apply(exports, depModules);
+                    if (amdResult !== undefined) {
+                        module.exports = amdResult;
+                    }
+                    _export(module.exports);
+                    _export('default', module.exports);
+                }
+            };
+        }
+    ];
+}
+
+/**
+ * Extract the registration context from an AMD module definition.
+ * @param nameOrDepsOrResource - The name, dependencies, or resource of the AMD module.
+ * @param depsOrFactory - The dependencies or factory function of the AMD module.
+ * @param factory - The factory function of the AMD module.
+ * @returns The extracted registration context.
+ */
+function extractRegistrationContext(
+    nameOrDepsOrResource: string | string[] | object | AMD.ResourceFactory,
+    depsOrFactory?: string[] | AMD.ResourceFactory,
+    factory?: AMD.ResourceFactory
+): SystemJS.RegistrationContext {
+    const isNamedRegister = typeof nameOrDepsOrResource === 'string';
+    const name: string | null = isNamedRegister ? nameOrDepsOrResource : null;
+    const depArg: string[] | object | undefined = isNamedRegister ? depsOrFactory : nameOrDepsOrResource;
+    const execArg: AMD.ResourceFactory = (isNamedRegister ? factory : depsOrFactory) as AMD.ResourceFactory;
+
+    // The System.register(deps, exec) arguments
+    let deps: string[];
+    let exec: AMD.ResourceFactory;
+
+    // define([], function () {})
+    if (Array.isArray(depArg)) {
+        deps = depArg;
+        exec = execArg;
+    }
+    // define({})
+    else if (typeof depArg === 'object') {
+        deps = [];
+        exec = function () {
+            return depArg;
+        };
+    }
+    // define(function () {})
+    else if (typeof depArg === 'function') {
+        deps = ['require', 'exports', 'module'];
+        exec = depArg;
+    }
+    // invalid define call
+    else {
+        throw Error(errMsg(9, 'Invalid call to AMD define()'));
+    }
+
+    return [name, createAMDRegister(deps, exec)];
+}
+
+// ]]]>
+// End of AMD support extracted and refactored from 'systemjs/dist/extras/amd.js'

--- a/src/lib/dummy.ts
+++ b/src/lib/dummy.ts
@@ -1,3 +1,0 @@
-export function dummy(): string {
-    return 'dummy';
-}

--- a/src/lib/systemjs.d.ts
+++ b/src/lib/systemjs.d.ts
@@ -1,0 +1,78 @@
+export declare namespace ESM {
+    type Exports = Record<string, unknown> | unknown;
+
+    interface Module {
+        __useDefault?: boolean;
+        default?: Exports;
+        [Symbol.toStringTag]?: string;
+        [key: string]: unknown;
+    }
+
+    interface ModuleExport {
+        exports: Exports;
+        uri?: string;
+    }
+
+    interface ModuleContext {
+        meta: {
+            url: string;
+        };
+    }
+}
+
+export declare namespace AMD {
+    type ResourceFactory = (...args: unknown[]) => unknown;
+    type ModuleExport = ResourceFactory | ESM.Exports | ESM.ModuleExport;
+    type DefineSignature = (
+        nameOrDepsOrResource: string | string[] | object | ResourceFactory,
+        depsOrFactory?: string[] | ResourceFactory,
+        factory?: ResourceFactory
+    ) => void;
+    type Define = DefineSignature & { amd?: object };
+}
+
+export declare namespace SystemJS {
+    type ExportSignature = (module: string | ESM.Module | ESM.Exports, exports?: ESM.Exports) => void;
+    type ModuleExportSignature = (_export: ExportSignature, _context: ESM.ModuleContext) => ModuleDeclaration;
+    type ModuleSetter = (module: ESM.Module) => void;
+    type ModuleRegistration = [string[], ModuleExportSignature];
+    type RegistrationContext = [string | null, ModuleRegistration];
+
+    interface ModuleDeclaration {
+        setters: ModuleSetter[];
+        execute: () => void;
+    }
+
+    interface ImportMap {
+        imports: Record<string, string>;
+        scopes: Record<string, Record<string, string>>;
+    }
+
+    interface Instance {
+        constructor: Constructor;
+        has(name: string): boolean;
+        get(name: string): object;
+        set(name: string, module: object): void;
+        entries(): IterableIterator<string>;
+        import(name: string, parentUrl?: string, meta?: object): Promise<unknown>;
+        resolve(name: string, parentUrl: string): Promise<string>;
+        instantiate(url: string, firstParentUrl: string): Promise<SystemJS.ModuleRegistration | undefined>;
+        register(
+            nameOrDeps: string | string[],
+            depsOrExports: string[] | ModuleExportSignature,
+            exports?: ModuleExportSignature
+        ): void;
+        getRegister(): ModuleRegistration | undefined;
+        addImportMap(map: ImportMap): void;
+        registerRegistry: Record<string, ModuleRegistration>;
+    }
+
+    interface Constructor extends Instance {
+        new (): Instance;
+    }
+}
+
+export declare global {
+    var define: AMD.Define;
+    var System: SystemJS.Instance;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,1 @@
+export type { SystemJS } from 'lib/systemjs.d.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,0 @@
-export * from 'lib/dummy.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,3 @@
+export { AMDLoader } from 'lib/amd-loader.ts';
+
 export type { SystemJS } from 'lib/systemjs.d.ts';

--- a/tests/amd-loader.test.ts
+++ b/tests/amd-loader.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { AMDLoader } from 'lib/amd-loader.ts';
+import type { ESM } from 'lib/systemjs';
+import { samplesHost } from 'tests/setup/config.ts';
+import { Script } from 'tests/setup/utils.ts';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('AMDLoader', () => {
+    it('should instantiate without errors', () => {
+        expect(new AMDLoader()).toBeInstanceOf(AMDLoader);
+    });
+
+    it('should define a resource with an object (no error)', async () => {
+        const loader = new AMDLoader();
+        expect(() => loader.define('testResourceObjectNoError', { foo: 'bar' })).not.toThrow();
+    });
+
+    it('should define a resource with a string (module path) without error', () => {
+        const loader = new AMDLoader();
+        expect(() => loader.define('testResourcePathNoError', '/path/to/module.js')).not.toThrow();
+    });
+
+    it('should load a defined resource (object)', async () => {
+        const loader = new AMDLoader();
+        loader.define('testResourceObject', { foo: 'bar' });
+        const exports = await loader.load('testResourceObject');
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should load a defined resource with multiple exports (explicit)', async () => {
+        const loader = new AMDLoader();
+        const module = { resource1: { foo: 'bar' }, resource2: { baz: 'qux' } };
+        const expected = Object.assign(Object.create(null), module);
+        Object.defineProperty(expected, Symbol.toStringTag, { value: 'Module' });
+        loader.define('testResourceObject', module, true);
+        const exports = await loader.load('testResourceObject');
+        expect(exports).toEqual(expected);
+    });
+
+    it('should load a defined resource with multiple exports (implicit)', async () => {
+        const loader = new AMDLoader();
+        const resources = { resource1: { foo: 'bar' }, resource2: { baz: 'qux' } };
+        const module = Object.assign(Object.create(null), resources);
+        Object.defineProperty(module, Symbol.toStringTag, { value: 'Module' });
+        loader.define('testResourceObject', module);
+        const exports = await loader.load('testResourceObject');
+        expect(exports).toEqual(module);
+    });
+
+    it('should load a defined resource (module path)', async () => {
+        const loader = new AMDLoader();
+        loader.define('testResourcePath', `${samplesHost}/resource.js`);
+        const exports = await loader.load('testResourcePath');
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should fail to load a defined resource if the import map fails', async () => {
+        const message = "Cannot read properties of undefined (reading 'slice')";
+        const loader = new AMDLoader();
+        loader.define('invalid', {});
+        await expect(loader.load('invalid')).rejects.toThrow(expect.objectContaining({ message }));
+    });
+
+    it('should load a resource module and return exports', async () => {
+        const loader = new AMDLoader();
+        const exports = await loader.load(`${samplesHost}/resource.js`);
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should not support resource "require"', async () => {
+        const message =
+            'AMD require not supported. (SystemJS Error#5 https://github.com/systemjs/systemjs/blob/main/docs/errors.md#5)';
+        const loader = new AMDLoader();
+        const exports = (await loader.load(`${samplesHost}/exports.js`)) as { require: () => void };
+        expect(exports).toEqual(expect.any(Object));
+        expect(exports).toHaveProperty('require');
+        expect(() => exports.require()).toThrow(expect.objectContaining({ message }));
+    });
+
+    it('should support resource "module"', async () => {
+        const loader = new AMDLoader();
+        const exports = (await loader.load(`${samplesHost}/exports.js`)) as { module: ESM.ModuleExport };
+        expect(exports).toEqual(expect.any(Object));
+        expect(exports).toHaveProperty('module');
+        expect(exports.module.exports).toEqual(exports);
+        expect(exports.module.uri).toEqual(`${samplesHost}/exports.js`);
+    });
+
+    it('should support resource "exports"', async () => {
+        const loader = new AMDLoader();
+        const exports = (await loader.load(`${samplesHost}/exports.js`)) as { foo: string };
+        expect(exports).toEqual(expect.any(Object));
+        expect(exports).toHaveProperty('foo');
+        expect(exports.foo).toEqual('bar');
+    });
+
+    it('should fail to load an invalid resource', async () => {
+        const message =
+            'Invalid call to AMD define() (SystemJS Error#9 https://github.com/systemjs/systemjs/blob/main/docs/errors.md#9)';
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/invalid.js`)).rejects.toThrow(expect.objectContaining({ message }));
+    });
+
+    it('should fail if an unhandled exception occurs during import (invalid define call)', async () => {
+        const message =
+            'Invalid call to AMD define() (SystemJS Error#9 https://github.com/systemjs/systemjs/blob/main/docs/errors.md#9)';
+        const evaluatorSpy = vi.spyOn(Script, 'evaluate').mockImplementation(() => {
+            window.dispatchEvent(
+                new ErrorEvent('error', {
+                    message,
+                    error: new Error(message)
+                })
+            );
+        });
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/resource.js`)).rejects.toThrow(expect.objectContaining({ message }));
+        expect(evaluatorSpy).toHaveBeenCalled();
+    });
+
+    it('should fail if an unhandled exception occurs during import (error in evaluate)', async () => {
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/error.js`)).rejects.toThrow(TypeError);
+    });
+
+    it('should not capture unrelated unhandled exceptions occurring during import', async () => {
+        const evaluatorSpy = vi.spyOn(Script, 'evaluate').mockImplementation(() => {
+            window.dispatchEvent(
+                new ErrorEvent('error', {
+                    message: 'Unrelated error',
+                    error: new Error('Unrelated error')
+                })
+            );
+        });
+        const loader = new AMDLoader();
+        try {
+            (await loader.load(`${samplesHost}/exports.js`)) as { foo: string };
+        } catch (error) {
+            expect(error).toEqual(expect.any(Error));
+        }
+        expect(evaluatorSpy).toHaveBeenCalled();
+    });
+
+    it('should continue the flow after a successful import', async () => {
+        const loader = new AMDLoader();
+        await loader.load(`${samplesHost}/bundle.js`);
+        await loader.load(`${samplesHost}/exports.js`);
+        const exports = await loader.load(`${samplesHost}/resource.js`);
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should continue the flow after a failed import', async () => {
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/invalid.js`)).rejects.toThrow();
+        const exports = await loader.load(`${samplesHost}/resource.js`);
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should continue the flow after a failed import caused by an unhandled exception', async () => {
+        const evaluatorSpy = vi.spyOn(Script, 'evaluate').mockImplementation(() => {
+            window.dispatchEvent(
+                new ErrorEvent('error', {
+                    message: 'Unrelated error',
+                    error: new Error('Unrelated error')
+                })
+            );
+        });
+        const loader = new AMDLoader();
+        try {
+            (await loader.load(`${samplesHost}/bundle.js`)) as { foo: string };
+        } catch (error) {
+            expect(error).toEqual(expect.any(Error));
+        }
+        evaluatorSpy.mockRestore();
+        const exports = await loader.load(`${samplesHost}/resource.js`);
+        expect(exports).toEqual({ foo: 'bar' });
+    });
+
+    it('should load a bundle and return the last defined module', async () => {
+        const loader = new AMDLoader();
+        const exports = (await loader.load(`${samplesHost}/bundle.js`)) as { compose: (msg: string) => string };
+        expect(exports).toHaveProperty('compose');
+        expect(exports.compose).toBeInstanceOf(Function);
+        expect(exports.compose('Hello')).toBe('Hello from compose with external and resource');
+    });
+
+    it('should restore the original define function after a successful load', async () => {
+        const originalDefine = globalThis.define;
+        const define = vi.fn();
+        globalThis.define = define;
+        expect(globalThis.define).not.toBe(originalDefine);
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/resource.js`)).resolves.toEqual({ foo: 'bar' });
+        expect(globalThis.define).toBe(define);
+        globalThis.define = originalDefine;
+    });
+
+    it('should restore the original define function after a failed load', async () => {
+        const originalDefine = globalThis.define;
+        const define = vi.fn();
+        globalThis.define = define;
+        expect(globalThis.define).not.toBe(originalDefine);
+        const loader = new AMDLoader();
+        await expect(loader.load(`${samplesHost}/invalid.js`)).rejects.toThrow();
+        expect(globalThis.define).toBe(define);
+        globalThis.define = originalDefine;
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,8 +1,0 @@
-import { dummy } from 'lib/dummy.ts';
-import { describe, expect, it } from 'vitest';
-
-describe('main', () => {
-    it('dummy test', async () => {
-        expect(dummy()).toBe('dummy');
-    });
-});

--- a/tests/setup/config.ts
+++ b/tests/setup/config.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import { basename, resolve } from 'path';
+
+/**
+ * The host URL for the files server.
+ */
+export const samplesHost: string = 'http://files.test';
+
+/**
+ * Path to the sample files.
+ */
+export const samplesPath: string = resolve(__dirname, '../../public/samples');
+
+/**
+ * An object mapping sample names to their file paths.
+ */
+export const samples = fs.readdirSync(samplesPath).reduce<Record<string, string>>((acc, file) => {
+    acc[basename(file, '.js')] = resolve(samplesPath, file);
+    return acc;
+}, {});

--- a/tests/setup/setup-tests.ts
+++ b/tests/setup/setup-tests.ts
@@ -1,4 +1,65 @@
+import fs from 'fs';
+import type { SystemJS } from 'lib/systemjs.d.ts';
+import { basename } from 'path';
+import 'systemjs/dist/system.js';
+import { samples, samplesHost } from 'tests/setup/config.ts';
+import { Script } from 'tests/setup/utils.ts';
 import { afterEach, vi } from 'vitest';
+
+const systemJSPrototype = System.constructor.prototype;
+const instantiate = systemJSPrototype.instantiate;
+const addImportMap = systemJSPrototype.addImportMap;
+
+/**
+ * Override SystemJS.instantiate for serving sample files without requiring network access
+ */
+systemJSPrototype.instantiate = function (
+    url: string,
+    firstParentUrl: string
+): Promise<SystemJS.ModuleRegistration | undefined> {
+    // Rewrite the URL to a resource name when it is a sample file.
+    if (url.startsWith(samplesHost)) {
+        url = basename(url, '.js');
+    }
+
+    if (url in samples) {
+        const content = fs.readFileSync(samples[url], 'utf-8');
+
+        // Override the global define function to capture the register
+        const define = globalThis.define;
+        let register: SystemJS.ModuleRegistration | undefined;
+        globalThis.define = (...args) => {
+            define(...args);
+            register = this.getRegister();
+        };
+
+        // Evaluate the AMD source inside the current global scope
+        // so that it hits `globalThis.define` (scoped by AMDLoader.load)
+        Script.evaluate(content);
+
+        // Restore the global define function for the next call
+        globalThis.define = define;
+
+        // After define() runs, SystemJS will have stashed the register
+        // return it just like the real script loader would
+        return Promise.resolve(register);
+    } else {
+        return instantiate.call(this, url, firstParentUrl);
+    }
+};
+
+/**
+ * Override SystemJS.addImportMap for mocking import map failures
+ */
+systemJSPrototype.addImportMap = (newMap: SystemJS.ImportMap, mapBase?: string) => {
+    // Mock a failure in the import map.
+    // It occurs under peculiar circumstances difficult to reproduce, for instance when SSR applies.
+    // As the tests run under a single context (e.g browser or node), we cannot simulate both in one test.
+    if ('invalid' in newMap.imports) {
+        throw new TypeError("Cannot read properties of undefined (reading 'slice')");
+    }
+    addImportMap(newMap, mapBase);
+};
 
 afterEach(() => {
     vi.restoreAllMocks();

--- a/tests/setup/utils.ts
+++ b/tests/setup/utils.ts
@@ -1,0 +1,10 @@
+export class Script {
+    /**
+     * Evaluates a string of JavaScript code in the global context.
+     * @param content The JavaScript code to evaluate.
+     * @returns The result of the evaluated code.
+     */
+    static evaluate(content: string): unknown {
+        return new Function(content)();
+    }
+}


### PR DESCRIPTION
This pull request introduces a scoped AMD loader built on top of SystemJS, allowing for modular and isolated loading of AMD modules in the project. The main changes include the implementation of the `AMDLoader` class, updates to dependencies to support SystemJS, and the addition of various sample AMD modules for testing and demonstration. The previous dummy export has been removed in favor of the new loader functionality.

**AMD Loader Implementation and Integration**
* Added `src/lib/amd-loader.ts` implementing a scoped `AMDLoader` class for defining and loading AMD modules with isolated registries, flow control, and SystemJS integration. Includes utility functions for AMD registration and error handling.
* Updated `src/main.ts` to export `AMDLoader` and the `SystemJS` type, replacing the previous dummy export. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL1-R3) [[2]](diffhunk://#diff-f5539641d9fb797acb11de8d0c1c2c4e5d1ffadc2335928c18d89af6b574828cL1-L3)

**Dependency Management**
* Added `systemjs` as both a development and peer dependency in `package.json` to support AMD module loading.

**Sample Modules for Testing**
* Added multiple AMD sample modules in `public/samples/` (`bundle.js`, `external.js`, `internal.js`, `resource.js`, `exports.js`, `error.js`, `invalid.js`) for demonstrating and testing the loader's capabilities and error handling. [[1]](diffhunk://#diff-74945f4631d21d8c410a082ab8d99978d651aa57b2cb283e5aaaec72c622971dR1-R17) [[2]](diffhunk://#diff-cb0091706af6c94768fb2c93fabacf9daa891652d8670edab434809e08338106R1-R5) [[3]](diffhunk://#diff-7e9e987b09c27596d16bfed28d05ebb751acb885f62aa945078efd1fbbeddbe5R1-R7) [[4]](diffhunk://#diff-44cd41363c96fd0a4ba82609a73bcf29e3fca891dba77723d50fb3664aec2d87R1-R3) [[5]](diffhunk://#diff-40cb33d32011316209331c6119af2dca674f9ed19331f7b7a6c898a1c29d061dR1-R5) [[6]](diffhunk://#diff-48cc18c2681cff3126021b0faa05d6bafa4a954551bb7d86aa0dd5b5cff98290R1-R3) [[7]](diffhunk://#diff-e61363b24b295e9afe867690172bbcc492c8225ec1307f4e0bc9c74ca1a51f10R1)

**Documentation**
* Updated `CHANGELOG.md` to note the addition of the scoped AMD loader on top of SystemJS.