### PR TITLE
Feature/Add a PCI registry implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement a PCI registry
 - Implement a scoped AMD loader on top of SystemJS
 - Project's bootstrap.

--- a/src/lib/pci-registry.ts
+++ b/src/lib/pci-registry.ts
@@ -1,0 +1,160 @@
+import type { PCI } from 'lib/pci.d.ts';
+
+/**
+ * A registry for managing and retrieving PCI (Portable Custom Interaction) runtimes.
+ *
+ * This registry is usually used for creating the resource `qtiCustomInteractionContext`.
+ * This is the only resource a PCI's runtime can request from the host application.
+ * It allows registering and retrieving PCI runtimes.
+ * @example
+ * import { PCIRegistry } from 'pci-loader';
+ * const registry = new PCIRegistry();
+ *
+ * // Register a PCI's runtime
+ * registry.register({
+ *     typeIdentifier: 'myPCI',
+ *     getInstance(dom, config, state) {
+ *         // Minimal implementation of a PCI's runtime
+ *         const myInteraction = {
+ *             getResponse() { },
+ *             getState() { },
+ *             oncompleted() { }
+ *         };
+ *        if (typeof config.onready === 'function') {
+ *             config.onready(myInteraction, state);
+ *         }
+ *     }
+ * });
+ *
+ * // Prepare the container and config for rendering the PCI
+ * // Be sure to have the container prefilled with the layout expected by the PCI's runtime
+ * const container = document.querySelector('#pci-container');
+ *
+ * // The configuration for the PCI.
+ * const config = {
+ *     // The properties to pass to the PCI
+ *     properties: {
+ *         key: 'value'
+ *     },
+ *
+ *     // The response variable the PCI is bound to
+ *     boundTo: { 'RESPONSE': { base: { string: 'value' } } },
+ *
+ *     // The instance of the PCI is returned by a callback
+ *     onready: (interaction, state) => {
+ *         // Handle the PCI's readiness
+ *     },
+ * };
+ *
+ * // The state can contain anything needed to restore the PCI
+ * const state = {};
+ *
+ * // Get the PCI's runtime and render an instance into the given container
+ * registry.getInstance(typeIdentifier, container, config, state);
+ */
+export class PCIRegistry implements PCI.Registry {
+    #interactions: Map<string, PCI.Registration>;
+
+    constructor() {
+        this.#interactions = new Map();
+    }
+
+    /**
+     * Registers a PCI's runtime.
+     *
+     * A runtime is represented by an object containing a unique typeIdentifier and a getInstance function.
+     * @param interaction - The PCI's runtime to register.
+     * @param interaction.typeIdentifier - The unique identifier for the PCI's runtime.
+     * @param interaction.getInstance - A function that renders the PCI into a DOM element and calls
+     * the `onready` callback provided through the configuration parameter.
+     * @throws {TypeError} If the PCI's runtime is invalid (e.g. missing typeIdentifier or getInstance).
+     * @example
+     * import { PCIRegistry } from 'pci-loader';
+     * const registry = new PCIRegistry();
+     *
+     * // Register a PCI's runtime
+     * registry.register({
+     *     typeIdentifier: 'myPCI',
+     *     getInstance(dom, config, state) {
+     *         // Minimal implementation of a PCI's runtime
+     *         const myInteraction = {
+     *             getResponse() { },
+     *             getState() { },
+     *             oncompleted() { }
+     *         };
+     *
+     *         if (typeof config.onready === 'function') {
+     *             config.onready(myInteraction, state);
+     *         }
+     *     }
+     * });
+     */
+    register(interaction: PCI.Registration): void {
+        // Runtime validation - the context is invoked by an untrusted module
+        if (!interaction?.typeIdentifier || typeof interaction?.getInstance !== 'function') {
+            throw new TypeError('Invalid interaction');
+        }
+
+        this.#interactions.set(interaction.typeIdentifier, interaction);
+    }
+
+    /**
+     * Retrieves a registered PCI's runtime, then gets a new PCI's instance, passing in the provided parameters.
+     * @param typeIdentifier - The type identifier of the PCI.
+     * @param container - The DOM element to render the PCI into. Be sure to have the container prefilled with the layout expected by the PCI's runtime.
+     * @param configuration - The configuration options for the PCI.
+     * @param configuration.properties - Properties to be passed to the PCI, a list of key-value pairs.
+     * @param configuration.templateVariables - An object containing the templates variables as referenced in the PCI.
+     * @param configuration.boundTo - An object representing the response for this QTI interaction.
+     * Usually, it starts empty and would be the response returned by the previous execution of the PCI when the item is revisited.
+     * @param configuration.onready - A **mandatory** callback function the PCI must call once it is fully created and ready to operate.
+     * The instance of the PCI and the initial state must be supplied as parameters.
+     * @param configuration.ondone - An optional callback function the PCI **may** call to terminate the attempt.
+     * If the host supports it, it may supply this callback in order for the PCI to explicitly terminate the attempt,
+     * in the same way it is made using the standard endAttempt interaction.
+     * @param configuration.status - An optional value that specifies the item's status. If not specified, it should default to `interacting`.
+     * @param state - An object representing the initial state of the PCI. This is useful when rendering a new instance of a previously terminated PCI.
+     * @throws {ReferenceError} If the PCI's runtime is not registered.
+     * @example
+     * import { PCIRegistry } from 'pci-loader';
+     * const registry = new PCIRegistry();
+     *
+     * // Register a PCI's runtime
+     * registry.register({ typeIdentifier, ... });
+     *
+     * // Prepare the container and config for rendering the PCI
+     * // Be sure to have the container prefilled with the layout expected by the PCI's runtime
+     * const container = document.querySelector('#pci-container');
+     *
+     * // The configuration for the PCI.
+     * const config = {
+     *     // The properties to pass to the PCI
+     *     properties: {
+     *         key: 'value'
+     *     },
+     *
+     *     // The response variable the PCI is bound to
+     *     boundTo: { 'RESPONSE': { base: { string: 'value' } } },
+     *
+     *     // The instance of the PCI is returned by a callback
+     *     onready: (interaction, state) => {
+     *         // Handle the PCI's readiness
+     *     },
+     * };
+     *
+     * // The state can contain anything needed to restore the PCI
+     * const state = {};
+     *
+     * // Get the PCI's runtime and render an instance
+     * registry.getInstance(typeIdentifier, container, config, state);
+     */
+    getInstance(typeIdentifier: string, container: Element, configuration: PCI.Config, state: PCI.State): void {
+        const interaction = this.#interactions.get(typeIdentifier);
+        if (!interaction) {
+            throw new ReferenceError(`Interaction "${typeIdentifier}" not found`);
+        }
+        interaction.getInstance(container, configuration, state);
+    }
+}
+
+export default PCIRegistry;

--- a/src/lib/pci.d.ts
+++ b/src/lib/pci.d.ts
@@ -1,0 +1,202 @@
+/**
+ * Defines data structures for PCI (Portable Custom Interaction).
+ */
+export declare namespace PCI {
+    type Cardinality = 'single' | 'multiple' | 'ordered' | 'record';
+    type BaseType =
+        | 'null'
+        | 'boolean'
+        | 'integer'
+        | 'float'
+        | 'string'
+        | 'point'
+        | 'pair'
+        | 'directedPair'
+        | 'duration'
+        | 'file'
+        | 'uri'
+        | 'identifier'
+        | 'intOrIdentifier';
+
+    interface SingleBoolean {
+        boolean: boolean;
+    }
+    interface SingleInteger {
+        integer: number;
+    }
+    interface SingleFloat {
+        float: number;
+    }
+    interface SingleString {
+        string: string;
+    }
+    interface SinglePoint {
+        point: [number, number];
+    }
+    interface SinglePair {
+        pair: [string, string];
+    }
+    interface SingleDirectedPair {
+        directedPair: [string, string];
+    }
+    interface SingleDuration {
+        duration: string;
+    }
+    interface SingleFile {
+        file: { data: string; mime: string; name: string };
+    }
+    interface SingleURI {
+        uri: string;
+    }
+    interface SingleIdentifier {
+        identifier: string;
+    }
+    interface SingleIntOrIdentifier {
+        intOrIdentifier: number | string;
+    }
+
+    interface MultipleBoolean {
+        boolean: boolean[];
+    }
+    interface MultipleInteger {
+        integer: number[];
+    }
+    interface MultipleFloat {
+        float: number[];
+    }
+    interface MultipleString {
+        string: string[];
+    }
+    interface MultiplePoint {
+        point: [number, number][];
+    }
+    interface MultiplePair {
+        pair: [string, string][];
+    }
+    interface MultipleDirectedPair {
+        directedPair: [string, string][];
+    }
+    interface MultipleDuration {
+        duration: string[];
+    }
+    interface MultipleFile {
+        file: { data: string; mime: string; name: string }[];
+    }
+    interface MultipleURI {
+        uri: string[];
+    }
+    interface MultipleIdentifier {
+        identifier: string[];
+    }
+    interface MultipleIntOrIdentifier {
+        intOrIdentifier: (number | string)[];
+    }
+
+    interface RecordNull {
+        name: null;
+    }
+    interface RecordSingle {
+        name: string;
+        base:
+            | null
+            | SingleBoolean
+            | SingleInteger
+            | SingleFloat
+            | SingleString
+            | SinglePoint
+            | SinglePair
+            | SingleDirectedPair
+            | SingleDuration
+            | SingleFile
+            | SingleURI
+            | SingleIdentifier
+            | SingleIntOrIdentifier;
+    }
+    interface RecordMultiple {
+        name: string;
+        list:
+            | MultipleBoolean
+            | MultipleInteger
+            | MultipleFloat
+            | MultipleString
+            | MultiplePoint
+            | MultiplePair
+            | MultipleDirectedPair
+            | MultipleDuration
+            | MultipleFile
+            | MultipleURI
+            | MultipleIdentifier
+            | MultipleIntOrIdentifier;
+    }
+
+    interface SingleCardinality {
+        base:
+            | null
+            | SingleBoolean
+            | SingleInteger
+            | SingleFloat
+            | SingleString
+            | SinglePoint
+            | SinglePair
+            | SingleDirectedPair
+            | SingleDuration
+            | SingleFile
+            | SingleURI
+            | SingleIdentifier
+            | SingleIntOrIdentifier;
+    }
+    interface MultipleCardinality {
+        list:
+            | MultipleBoolean
+            | MultipleInteger
+            | MultipleFloat
+            | MultipleString
+            | MultiplePoint
+            | MultiplePair
+            | MultipleDirectedPair
+            | MultipleDuration
+            | MultipleFile
+            | MultipleURI
+            | MultipleIdentifier
+            | MultipleIntOrIdentifier;
+    }
+    interface RecordCardinality {
+        record: (RecordNull | RecordSingle | RecordMultiple)[];
+    }
+
+    type Response = SingleCardinality | MultipleCardinality | RecordCardinality;
+
+    interface State {
+        response?: Response;
+        [key: string]: unknown;
+    }
+
+    interface Config {
+        properties: Record<string, unknown>;
+        templateVariables?: Record<string, Response>;
+        boundTo?: { [key: string]: Response };
+        onready: (interaction: Interaction, state: State) => void;
+        ondone?: (interaction: Interaction, response: Response, state: State, status: string) => void;
+        status?: string;
+    }
+
+    interface Registration {
+        typeIdentifier: string;
+        getInstance: (container: Element, configuration: Config, state: State) => void;
+    }
+
+    interface Interaction {
+        getResponse: () => Response;
+        getState: () => State;
+        oncompleted: () => void;
+        [key: string]: unknown;
+    }
+
+    interface RegistryContext {
+        register: (interaction: Registration) => void;
+    }
+    interface RegistryGetter {
+        getInstance: (typeIdentifier: string, container: Element, configuration: Config, state: State) => void;
+    }
+    interface Registry extends RegistryContext, RegistryGetter {}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
 export { AMDLoader } from 'lib/amd-loader.ts';
 
+export type { PCI } from 'lib/pci.d.ts';
 export type { SystemJS } from 'lib/systemjs.d.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 export { AMDLoader } from 'lib/amd-loader.ts';
+export { PCIRegistry } from 'lib/pci-registry.ts';
 
 export type { PCI } from 'lib/pci.d.ts';
 export type { SystemJS } from 'lib/systemjs.d.ts';

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { PCIRegistry } from 'lib/pci-registry.ts';
+import type { PCI } from 'lib/pci.d.ts';
+import { describe, expect, it, vi } from 'vitest';
+
+const createMockInteraction = (typeIdentifier = 'mockPCI') => ({
+    typeIdentifier,
+    getInstance: (_container: Element, config: PCI.Config, state: PCI.State) => {
+        if (typeof config.onready === 'function') {
+            config.onready(
+                {
+                    getResponse(): PCI.Response {
+                        return { base: null };
+                    },
+                    getState(): PCI.State {
+                        return {};
+                    },
+                    oncompleted() {}
+                },
+                state
+            );
+        }
+    }
+});
+
+describe('PCIRegistry', () => {
+    it('should register a valid interaction', () => {
+        const registry = new PCIRegistry();
+        const interaction = createMockInteraction();
+        expect(() => registry.register(interaction)).not.toThrow();
+    });
+
+    it('should throw TypeError for invalid interaction', () => {
+        const registry = new PCIRegistry();
+        // Missing typeIdentifier
+        // @ts-expect-error Check missing typeIdentifier
+        expect(() => registry.register({ getInstance: () => {} })).toThrow(TypeError);
+        // Missing getInstance
+        // @ts-expect-error Check missing getInstance
+        expect(() => registry.register({ typeIdentifier: 'badPCI' })).toThrow(TypeError);
+    });
+
+    it('should retrieve and invoke a registered interaction', () => {
+        const registry = new PCIRegistry();
+        const interaction = createMockInteraction('testPCI');
+        registry.register(interaction);
+        const container = document.createElement('div');
+        const config = {
+            onready: vi.fn() as PCI.Config['onready']
+        } as PCI.Config;
+        const state = {} as PCI.State;
+        registry.getInstance('testPCI', container, config, state);
+        expect(config.onready).toBeCalled();
+    });
+
+    it('should throw Error if interaction is not registered', () => {
+        const registry = new PCIRegistry();
+        const container = document.createElement('div');
+        const config = {
+            onready: vi.fn() as PCI.Config['onready']
+        } as PCI.Config;
+        const state = {} as PCI.State;
+        expect(() => registry.getInstance('unknownPCI', container, config, state)).toThrow(Error);
+        expect(config.onready).not.toBeCalled();
+    });
+});


### PR DESCRIPTION
This pull request introduces a new PCI registry feature to the codebase, enabling the registration and retrieval of Portable Custom Interaction (PCI) runtimes. The main changes include the implementation of the `PCIRegistry` class, its export in the main module, and comprehensive unit tests to ensure correct behavior and error handling.

### PCI Registry Implementation

* Added the `PCIRegistry` class in `src/lib/pci-registry.ts`, which provides methods to register PCI runtimes and retrieve instances based on a type identifier. Includes runtime validation and error handling for missing or invalid registrations.
* Updated `CHANGELOG.md` to document the addition of the PCI registry feature.

### Module Exports

* Exported `PCIRegistry` and the `PCI` type from `src/main.ts` to make the registry available for external use.

### Testing

* Added a new test suite in `tests/registry.test.ts` to verify PCI registry functionality, including registration, instance retrieval, and error scenarios for invalid or missing PCI runtimes.