### PR TITLE
Feature/Handle external 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,7 @@
 
 A tiny TypeScript library for dynamically loading and managing PCI (Portable Custom Interaction) runtimes in modern web applications. It provides a scoped loader and registry for PCI modules, supporting AMD and SystemJS formats.
 
-<!-- vscode-markdown-toc -->
-
-- [Features](#features)
-- [Main Components](#main-components)
-- [Installation](#installation)
-- [Example Usage](#example-usage)
-- [Definition](#definition)
-- [API Reference](#api-reference)
-    - [PCILoader](#pciloader)
-    - [PCIRegistry](#pciregistry)
-    - [AMDLoader](#amdloader)
-- [Scripts](#scripts)
-- [Changes](#changes)
-- [License](#license)
-
-<!-- vscode-markdown-toc-config
-	numbering=false
-	autoSave=true
-	/vscode-markdown-toc-config -->
-<!-- /vscode-markdown-toc -->
-
-## <a name='features'></a>Features
+## Features
 
 - **Dynamic PCI loading**: Load PCI runtimes at runtime from URLs.
 - **Scoped registry**: Each loader instance manages its own PCI registry.
@@ -31,19 +10,19 @@ A tiny TypeScript library for dynamically loading and managing PCI (Portable Cus
 - **Custom interaction context**: Exposes only the `qtiCustomInteractionContext` resource to loaded PCIs.
 - **TypeScript support**: Fully typed API for safe integration.
 
-## <a name='main-components'></a>Main Components
+## Main Components
 
 - **PCILoader**: Loads a PCI's runtime and manages its registration and instantiation.
 - **PCIRegistry**: Registers and retrieves PCI runtimes, and creates PCI instances.
 - **AMDLoader**: Handles AMD module loading using SystemJS.
 
-## <a name='installation'></a>Installation
+## Installation
 
 ```sh
 npm install pci-loader
 ```
 
-## <a name='example-usage'></a>Example Usage
+## Example Usage
 
 ```typescript
 import { PCILoader } from 'pci-loader';
@@ -65,7 +44,7 @@ loader
     });
 ```
 
-## <a name='definition'></a>Definition
+## Definition
 
 **PCI** stands for **P**ortable **C**ustom **I**nteraction. This is a specification from [1EdTech](https://www.imsglobal.org/assessment/interactions.html) (previously “IMS Global”).
 
@@ -94,9 +73,9 @@ define('my/PCI/runtime', ['qtiCustomInteractionContext'], function (qtiCustomInt
 });
 ```
 
-## <a name='api-reference'></a>API Reference
+## API Reference
 
-### <a name='pciloader'></a>PCILoader
+### PCILoader
 
 Loads a PCI's runtime in a scoped manner and manages its registration and instantiation.
 
@@ -387,7 +366,7 @@ loader
 
 ---
 
-### <a name='pciregistry'></a>PCIRegistry
+### PCIRegistry
 
 A registry for managing and retrieving PCI (Portable Custom Interaction) runtimes.
 
@@ -568,7 +547,7 @@ registry.getInstance(typeIdentifier, container, config, state);
 
 ---
 
-### <a name='amdloader'></a>AMDLoader
+### AMDLoader
 
 A utility for loading AMD modules and defining resources in a scoped context using [SystemJS](https://github.com/systemjs/systemjs).
 
@@ -714,7 +693,7 @@ loader
 
 ---
 
-## <a name='scripts'></a>Scripts
+## Scripts
 
 - `dev`: Start development server with Vite
 - `build`: Build the library
@@ -723,10 +702,10 @@ loader
 
 ---
 
-## <a name='changes'></a>Changes
+## Changes
 
 For the changelog, see [CHANGELOG.md](CHANGELOG.md).
 
-## <a name='license'></a>License
+## License
 
 Distributed under the [MIT License](./LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "typescript-eslint": "^8.40.0",
                 "vite": "^7.1.3",
                 "vite-plugin-dts": "^4.5.4",
+                "vite-plugin-static-copy": "^3.1.2",
                 "vitest": "^3.2.4"
             },
             "engines": {
@@ -2646,6 +2647,33 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/anymatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2708,6 +2736,19 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -2802,6 +2843,44 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 16"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/clsx": {
@@ -3862,6 +3941,19 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -4429,6 +4521,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.21",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
@@ -4481,6 +4583,19 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4864,6 +4979,32 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/readdirp/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
@@ -5822,6 +5963,26 @@
                 "vite": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-plugin-static-copy": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.2.tgz",
+            "integrity": "sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^3.6.0",
+                "fs-extra": "^11.3.0",
+                "p-map": "^7.0.3",
+                "picocolors": "^1.1.1",
+                "tinyglobby": "^0.2.14"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
         "node_modules/vitefu": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "typescript-eslint": "^8.40.0",
         "vite": "^7.1.3",
         "vite-plugin-dts": "^4.5.4",
+        "vite-plugin-static-copy": "^3.1.2",
         "vitest": "^3.2.4"
     },
     "peerDependencies": {

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Page Not Found</title>
+        <style>
+            :root {
+                --font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+                --font-size: 14px;
+                --font-weight: 400;
+                --line-height: 1.5;
+
+                --background: #efe8e4;
+                --text-color: #213547;
+                --text-color-muted: #888;
+
+                --link-color: #424cff;
+                --link-hover-color: #101bf2;
+                --link-focus: #646cff;
+
+                font-family: var(--font-family);
+                line-height: var(--line-height);
+                font-weight: var(--font-weight);
+
+                color-scheme: light dark;
+                color: var(--text-color);
+                background-color: var(--background);
+
+                font-synthesis: none;
+                text-rendering: optimizeLegibility;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    --background: #242424;
+                    --text-color: rgba(255, 255, 255, 0.87);
+                    --text-color-muted: #888;
+
+                    --link-color: #868cff;
+                    --link-hover-color: #757bf2;
+                    --link-focus: #646cff;
+                }
+            }
+
+            *,
+            *::before,
+            *::after {
+                box-sizing: border-box;
+            }
+
+            a {
+                appearance: none;
+                position: relative;
+                font-weight: 500;
+                outline: none;
+                color: var(--link-color);
+                text-decoration: inherit;
+            }
+            a:hover {
+                color: var(--link-hover-color);
+            }
+            a:focus::after,
+            a:focus-visible::after {
+                content: '';
+                position: absolute;
+                top: -4px;
+                left: -6px;
+                right: -6px;
+                bottom: -4px;
+                border: 2px solid var(--link-focus);
+                border-radius: var(--link-border-radius, 4px);
+            }
+        </style>
+        <script>
+            // Redirect all 404s to the homepage, preserving the path
+            var path = window.location.pathname + window.location.search + window.location.hash;
+            window.localStorage.setItem('redirectPath', path);
+            window.location.replace('/');
+        </script>
+    </head>
+    <body>
+        <h1>404 - Not Found</h1>
+        <p>The page you are looking for does not exist.</p>
+        <p>Redirecting you to the <a href="/" title="Homepage">homepage...</a></p>
+    </body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -77,12 +77,12 @@
             // Redirect all 404s to the homepage, preserving the path
             var path = window.location.pathname + window.location.search + window.location.hash;
             window.localStorage.setItem('redirectPath', path);
-            window.location.replace('/');
+            window.location.replace('__BASE_URL__');
         </script>
     </head>
     <body>
         <h1>404 - Not Found</h1>
         <p>The page you are looking for does not exist.</p>
-        <p>Redirecting you to the <a href="/" title="Homepage">homepage...</a></p>
+        <p>Redirecting you to the <a href="__BASE_URL__" title="Homepage">homepage...</a></p>
     </body>
 </html>

--- a/src/demo/App.svelte
+++ b/src/demo/App.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { mainMenu } from 'demo/config.ts';
     import { p } from 'demo/router.ts';
-    import type { router } from 'demo/types.d.ts';
     import packageInfo from 'root/package.json';
     import { isActiveLink, Router } from 'sv-router';
 
@@ -18,7 +17,7 @@
             </svg>
             <menu>
                 {#each mainMenu as item}
-                    <a href={(p as router.Navigate)(item.url, item.params)} use:isActiveLink>{item.label}</a>
+                    <a href={p(item.url, item.params)} use:isActiveLink>{item.label}</a>
                 {/each}
             </menu>
             <svg viewBox="0 0 2 3" aria-hidden="true">

--- a/src/demo/router.ts
+++ b/src/demo/router.ts
@@ -20,5 +20,15 @@ const routeMap = routes.reduce((acc: router.RouteMap, route: router.Route) => {
 
 export const { p, navigate, isActive, route }: router.RouterExports = createRouter({
     ...routeMap,
-    '*': NotFound
+    '*': NotFound,
+    hooks: {
+        async afterLoad() {
+            // Manage redirection from external 404 page (public/404.html)
+            const path = window.localStorage.getItem('redirectPath');
+            window.localStorage.removeItem('redirectPath');
+            if (path) {
+                navigate(`/${path}`.replace(/\/+/g, '/'));
+            }
+        }
+    }
 }) as unknown as router.RouterExports;

--- a/src/demo/router.ts
+++ b/src/demo/router.ts
@@ -18,7 +18,7 @@ const routeMap = routes.reduce((acc: router.RouteMap, route: router.Route) => {
     return acc;
 }, {} as router.RouteMap);
 
-export const { p, navigate, isActive, route } = createRouter({
+export const { p, navigate, isActive, route }: router.RouterExports = createRouter({
     ...routeMap,
     '*': NotFound
-});
+}) as unknown as router.RouterExports;

--- a/src/demo/types.d.ts
+++ b/src/demo/types.d.ts
@@ -39,4 +39,19 @@ export declare namespace router {
     export type RouteMap = Record<string, Component>;
 
     export type Navigate = (url: string, params?: Record<string, unknown>) => string;
+    export type isActive = (url: string) => boolean;
+    export type RouterExports = {
+        p: Navigate;
+        navigate: Navigate;
+        isActive: isActive;
+        route: {
+            params: AllParams<T>;
+            getParams<U extends Path<T>>(pathname: U): Record<ExtractParams<U>, string>;
+            pathname: (Path<T, true> & {}) | (string & {});
+            search: string;
+            state: unknown;
+            hash: string;
+            meta: RouteMeta;
+        };
+    };
 }

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -3,6 +3,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { resolve } from 'path';
 import type { AliasOptions, ESBuildOptions, PluginOption, UserConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import type { ViteUserConfig } from 'vitest/config';
 import packageInfo from './package.json';
 
@@ -131,7 +132,19 @@ export const staticConfig: UserConfig = {
         }
     },
     esbuild,
-    plugins,
+    plugins: [
+        ...plugins,
+        // Copy HTML files and inject Vite's global constants into them
+        viteStaticCopy({
+            targets: [
+                {
+                    src: 'public/*.html',
+                    dest: '.',
+                    transform: contents => contents.toString().replace(/__BASE_URL__/g, baseUrl)
+                }
+            ]
+        })
+    ],
     resolve: {
         alias
     }


### PR DESCRIPTION
This pull request includes several documentation and build improvements, as well as a small fix to demo navigation and router handling. The main changes are the removal of the markdown table of contents from `README.md` for clarity, the addition of a custom 404 page for static hosting with automatic redirection, and updates to the build configuration to copy and inject variables into HTML files. Additionally, there are minor code cleanups and a fix to the demo router to handle external 404 redirects.

**Documentation improvements:**

* Removed the auto-generated markdown table of contents from `README.md` and updated all section headers for clarity and consistency. This makes the documentation easier to read and maintain. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R47) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R78) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L390-R369) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L571-R550) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L717-R696) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L726-R709)

**Static hosting and build enhancements:**

* Added a custom `public/404.html` page that automatically redirects users to the homepage, preserving the original path so the router can handle it after the redirect.
* Updated `package.json` to include `vite-plugin-static-copy` as a dev dependency for copying and transforming static files during the build.
* Modified `vite.config.shared.ts` to use `vite-plugin-static-copy` for copying HTML files and injecting the base URL, improving deployment flexibility. [[1]](diffhunk://#diff-8d70d942909bee4dc6eae2df880b7ac6ce4a4e792f493755af4b2fb7ffe47396R6) [[2]](diffhunk://#diff-8d70d942909bee4dc6eae2df880b7ac6ce4a4e792f493755af4b2fb7ffe47396L134-R147)

**Demo and router fixes:**

* Cleaned up demo navigation code in `App.svelte` to simplify link generation and removed unnecessary type casts. [[1]](diffhunk://#diff-ad7787d93dfd24b34d6037356e90e3b3b0ef85c1360a6ead6af4b52067ca4bcaL4) [[2]](diffhunk://#diff-ad7787d93dfd24b34d6037356e90e3b3b0ef85c1360a6ead6af4b52067ca4bcaL21-R20)
* Updated `src/demo/router.ts` to handle redirects from the custom 404 page by checking for a stored path and navigating to it after load.