### PR TITLE
Feature/Automerge release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: write
+    pull-requests: write
+    checks: read
+
+jobs:
+    merge_pull_request:
+        if: startsWith(github.head_ref, 'release/')
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions"
+                  git config user.email "github-actions@github.com"
+
+            - name: Automerge Pull Request
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+              run: gh pr merge --merge --admin --delete-branch "${{ env.PULL_REQUEST_NUMBER }}"
+
+            - name: Create and push tag on main
+              env:
+                  PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+              run: |
+                  git fetch --all
+                  git fetch --tags
+                  git checkout main
+                  git pull
+                  git tag "${{ env.PULL_REQUEST_TITLE }}"
+                  git push origin "${{ env.PULL_REQUEST_TITLE }}"
+
+            - name: Create GitHub Release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+                  PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+              with:
+                  tag_name: ${{ env.PULL_REQUEST_TITLE }}
+                  release_name: ${{ env.PULL_REQUEST_TITLE }}
+                  body: ${{ env.PULL_REQUEST_BODY }}
+                  draft: false
+                  prerelease: false


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow is triggered when a pull request targeting the `main` branch is opened and its branch name starts with `release/`. The workflow handles automerging, tagging, and creating a GitHub release.

**Release automation:**

* Added `.github/workflows/release.yaml` to automate merging of release pull requests into `main`, creation and pushing of a git tag based on the pull request title, and publishing a GitHub release with the pull request details.