### PR TITLE
Fix/Workflow triggers after release

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,6 +6,11 @@ on:
 
     workflow_dispatch:
 
+    workflow_run:
+        workflows: ['Release']
+        types:
+            - completed
+
 permissions:
     contents: read
     pages: write

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -4,6 +4,8 @@ on:
     push:
         branches: [main]
 
+    workflow_dispatch:
+
 permissions:
     contents: write
 

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -6,6 +6,11 @@ on:
 
     workflow_dispatch:
 
+    workflow_run:
+        workflows: ['Release']
+        types:
+            - completed
+
 permissions:
     contents: write
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers for both the `gh-pages.yaml` and `sync.yaml` workflow files. The main change is to allow these workflows to be triggered automatically after the completion of the `Release` workflow, in addition to their previous triggers.

**Workflow trigger enhancements:**

* Added `workflow_run` trigger to both `.github/workflows/gh-pages.yaml` and `.github/workflows/sync.yaml` so that these workflows are triggered when the `Release` workflow completes. [[1]](diffhunk://#diff-9f184e11981c71caabf911f9140c261b8d76c4fc9d623fae79063200ad744477R9-R13) [[2]](diffhunk://#diff-c0331e5bfbabc4af0a8a89a0bfd35411cf0626b31545e5440e5ccd931b23d845R7-R13)
* Added `workflow_dispatch` trigger to `.github/workflows/sync.yaml` to allow manual triggering of the workflow.