### PR TITLE
Feature/Control code autoformat

### DIFF
--- a/src/demo/components/Code.svelte
+++ b/src/demo/components/Code.svelte
@@ -6,15 +6,18 @@
 
     interface Props {
         code: string | undefined;
+        autoformat?: boolean;
     }
 
-    let { code }: Props = $props();
+    let { code, autoformat = false }: Props = $props();
 
     let formattedCode: string | undefined = $derived(code);
 
-    (async () => {
-        formattedCode = await prettify(code || '');
-    })();
+    if (autoformat) {
+        (async () => {
+            formattedCode = await prettify(code || '');
+        })();
+    }
 </script>
 
 <CopyToClipboard content={formattedCode}>

--- a/src/demo/components/CodeFile.svelte
+++ b/src/demo/components/CodeFile.svelte
@@ -3,9 +3,10 @@
 
     interface Props {
         url?: string;
+        autoformat?: boolean;
     }
 
-    let { url }: Props = $props();
+    let { url, autoformat = false }: Props = $props();
     let code: string = $state('');
     let fileName: string = $state('');
 
@@ -20,7 +21,7 @@
 
 <article>
     <header>File: <code>{fileName}</code></header>
-    <Code {code} />
+    <Code {code} {autoformat} />
 </article>
 
 <style>

--- a/src/demo/components/MarkdownCode.svelte
+++ b/src/demo/components/MarkdownCode.svelte
@@ -13,7 +13,7 @@
 </script>
 
 {#if supportedLanguages.includes(lang)}
-    <Code code={text} />
+    <Code code={text} autoformat={false} />
 {:else}
     <CopyToClipboard content={text}>
         <pre class={lang}><code>{text}</code></pre>

--- a/src/demo/components/Playground.svelte
+++ b/src/demo/components/Playground.svelte
@@ -237,7 +237,7 @@
                     <div class={states.rendered ? 'pci-instance' : ''} bind:this={container}></div>
                     {#if output}
                         <span>{outputLabel || 'Output'}</span>
-                        <Code code={output} />
+                        <Code code={output} autoformat={true} />
                     {/if}
                 </div>
             </div>

--- a/src/demo/utils/utils.ts
+++ b/src/demo/utils/utils.ts
@@ -16,8 +16,15 @@ export async function prettify(snippet: string, notify: boolean = false): Promis
         plugins: [prettierPluginTypeScript, prettierPluginEstree, prettierPluginHtml],
         printWidth: 80,
         tabWidth: 4,
+        useTabs: false,
+        semi: true,
         singleQuote: true,
-        trailingComma: 'all'
+        quoteProps: 'as-needed',
+        trailingComma: 'none',
+        bracketSpacing: true,
+        arrowParens: 'avoid',
+        endOfLine: 'lf',
+        bracketSameLine: true
     };
 
     try {


### PR DESCRIPTION
This pull request introduces support for automatic code formatting in several demo components by adding an `autoformat` prop, and refines the code formatting behavior with updated Prettier options. The changes enhance code readability and consistency in the UI, especially for rendered code outputs.

### Code formatting feature

* Added an optional `autoformat` prop to the `Code`, `CodeFile`, and `MarkdownCode` components, enabling automatic code formatting when desired. (`src/demo/components/Code.svelte`, `src/demo/components/CodeFile.svelte`, `src/demo/components/MarkdownCode.svelte`) [[1]](diffhunk://#diff-2cfa2ad9aed2ef1bc756c7b6305506c14f7cf8e960b13eb03cfb41d1f62589fcR9-R20) [[2]](diffhunk://#diff-a4cf7d605e91ee91d11de6c0b8a859d3291b8edf2170d3d97a36f2b9e5c5e44dR6-R9) [[3]](diffhunk://#diff-a4cf7d605e91ee91d11de6c0b8a859d3291b8edf2170d3d97a36f2b9e5c5e44dL23-R24) [[4]](diffhunk://#diff-858455da97fee3c9ffdec987ea95ca49285558287fb342d1f141aa0cf0242d60L16-R16)
* Updated usage in `Playground.svelte` so that code output is automatically formatted when displayed. (`src/demo/components/Playground.svelte`)

### Prettier configuration improvements

* Refined Prettier options in `prettify` to enforce consistent formatting: spaces instead of tabs, semicolons, single quotes, minimal trailing commas, and other style preferences. (`src/demo/utils/utils.ts`)