### PR TITLE
Feature/Add PCILoader status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Status for the PCILoader (`initial`, `loading`, `loaded`, `error`)
+
 ## v1.0.2 [2025-08-26]
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ loader
 
 > **Portable Custom Interaction (PCI) defines a standard way for technology-enhanced items (TEIs) or custom interaction types** to be represented as part of the Question and Test Interoperability® (QTI®) and Accessible Portable Item Protocol® (APIP®) specifications.
 
-PCI runtimes should be defined following the [AMD API Specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md). Here is a simple example:
+PCI runtimes must be defined following the [AMD API Specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md). Here is a simple example:
 
 > **_File:_** `/path/to/myPCI/runtime.js`
 
@@ -152,12 +152,36 @@ _Parameters:_
 - `url: string` - The URL of the PCI's runtime script.
 - `name: string` - The name of the PCI (optional). If the name is provided, it must match the `typeIdentifier` of the PCI's runtime. Otherwise it will be extracted from the PCI's runtime itself.
 
+_Examples:_
+
+Create a new `PCILoader` instance for a particular PCI. Name will be extracted from the runtime.
+
+```typescript
+import { PCILoader } from 'pci-loader';
+
+const loader = new PCILoader('/path/to/myPCI/runtime.js');
+```
+
+Create a new `PCILoader` instance for a particular PCI, specifying the name, which must match the runtime's typeIdentifier.
+
+```typescript
+import { PCILoader } from 'pci-loader';
+
+const loader = new PCILoader('/path/to/myPCI/runtime.js', 'myPCI');
+```
+
 **Properties**
 
-- `name: string`
-  The name of the PCI. If not provided at construction, it will be extracted from the PCI's runtime itself. The value may be undefined if the PCI's runtime is not yet loaded.
-- `url: string`
-  The URL of the PCI's runtime.
+`name: string` - _`read-only`_ - The name of the PCI. If not provided at construction, it will be extracted from the PCI's runtime itself. The value may be undefined if the PCI's runtime is not yet loaded.
+
+`url: string` - _`read-only`_ - The URL of the PCI's runtime.
+
+`status: string` - _`read-only`_ - The status of the PCI loader. It will be:
+
+- `'initial'` when the loader is created.
+- `'loading'` when the PCI's runtime is being loaded.
+- `'loaded'` when the PCI's runtime is successfully loaded.
+- `'error'` if there was an error loading the PCI.
 
 **Methods**
 
@@ -186,25 +210,10 @@ _Returns:_
 
 _Examples:_
 
-Create a new `PCILoader` instance for a particular PCI. Name will be extracted from the runtime.
-
 ```typescript
 import { PCILoader } from 'pci-loader';
-
 const loader = new PCILoader('/path/to/myPCI/runtime.js');
-```
 
-Create a new `PCILoader` instance for a particular PCI, specifying the name, which must match the runtime's typeIdentifier.
-
-```typescript
-import { PCILoader } from 'pci-loader';
-
-const loader = new PCILoader('/path/to/myPCI/runtime.js', 'myPCI');
-```
-
-From the created `PCILoader`, we can now load the PCI's runtime, and possibly get an instance from it.
-
-```typescript
 loader
     .load()
     .then(registry => {

--- a/src/demo/components/Code.svelte
+++ b/src/demo/components/Code.svelte
@@ -14,9 +14,11 @@
     let formattedCode: string | undefined = $derived(code);
 
     if (autoformat) {
-        (async () => {
-            formattedCode = await prettify(code || '');
-        })();
+        $effect(() => {
+            prettify(code || '').then(async () => {
+                formattedCode = await prettify(code || '');
+            });
+        });
     }
 </script>
 

--- a/src/demo/components/CodeFile.svelte
+++ b/src/demo/components/CodeFile.svelte
@@ -10,13 +10,18 @@
     let code: string = $state('');
     let fileName: string = $state('');
 
-    (async () => {
+    $effect(() => {
         if (url) {
             fileName = url.split('/').pop() || '';
-            const response = await fetch(url);
-            code = await response.text();
+            fetch(url)
+                .then(async response => {
+                    code = await response.text();
+                })
+                .catch(err => {
+                    code = `// Error loading code: ${err.message}`;
+                });
         }
-    })();
+    });
 </script>
 
 <article>

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -2,6 +2,8 @@ export declare type PCILoaderOptions = {
     timeout?: number;
 };
 
+export declare type PCILoaderStatus = 'initial' | 'loading' | 'loaded' | 'error';
+
 export declare type PromiseTimeoutOptions = {
     timeout?: number;
     message?: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,4 +3,4 @@ export { PCILoader } from 'lib/pci-loader.ts';
 export { PCIRegistry } from 'lib/pci-registry.ts';
 export { TimeoutError } from 'lib/timeout.ts';
 
-export type { PCI, PCILoaderOptions, SystemJS } from 'lib/types.d.ts';
+export type { PCI, PCILoaderOptions, PCILoaderStatus, SystemJS } from 'lib/types.d.ts';


### PR DESCRIPTION
This pull request introduces a new status property to the `PCILoader` class, enabling better tracking of the loader's lifecycle state. The documentation and tests have been updated to reflect this addition, and minor improvements were made to demo components and type exports. The most important changes are grouped below:

### PCILoader Status Property and Lifecycle

* Added a `status` property to the `PCILoader` class, with possible values `'initial'`, `'loading'`, `'loaded'`, and `'error'`, to reflect the loader's current state. The status is updated appropriately during the loading process and on errors. [[1]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR90) [[2]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR101) [[3]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR121-R133) [[4]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL188-R203) [[5]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR223-R242)
* Updated tests for `PCILoader` to check status transitions throughout the loading lifecycle, including error scenarios. [[1]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R21-R25) [[2]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R39-R46) [[3]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R74) [[4]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R86) [[5]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R109) [[6]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R139) [[7]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27L140-R169) [[8]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R184)

### Documentation Updates

* Updated the `README.md` to document the new `status` property for `PCILoader`, including its possible values and usage examples. Also clarified that PCI runtimes must follow the AMD API Specification. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R155-R184) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L189-L207)
* Added a note about the new status property to the `CHANGELOG.md` under "Added".

### Type Exports

* Exported the new `PCILoaderStatus` type in the main entry file for external usage. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL6-R6) [[2]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL4-R4)

### Demo Component Improvements

* Refactored demo components (`Code.svelte` and `CodeFile.svelte`) to use reactive `$effect` for code formatting and file loading, improving readability and error handling. [[1]](diffhunk://#diff-2cfa2ad9aed2ef1bc756c7b6305506c14f7cf8e960b13eb03cfb41d1f62589fcL17-R21) [[2]](diffhunk://#diff-a4cf7d605e91ee91d11de6c0b8a859d3291b8edf2170d3d97a36f2b9e5c5e44dL13-R24)

---

These changes collectively enhance the reliability, observability, and usability of the PCI loader functionality.