### PR TITLE
Fix/PCILoader race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Possible race condition when calling PCILoader.load() multiple times
+
 ## v1.1.0 [2025-08-27]
 
 ### Added

--- a/public/samples/value.js
+++ b/public/samples/value.js
@@ -1,0 +1,3 @@
+define({
+    value: 42
+});

--- a/src/lib/amd-loader.ts
+++ b/src/lib/amd-loader.ts
@@ -76,6 +76,9 @@ export class AMDLoader {
      * The resource may be a preloaded module or a mapping to a different location.
      * @param name - The name of the resource.
      * @param module - An URI string or the resource object.
+     * @param esm - Tells if the module must be treated as an ESM module.
+     * - If true, the module is used as-is.
+     * - If false (default), the module is wrapped to be the default export of an ESM module.
      * @example
      * import { AMDLoader } from 'pci-loader';
      * loader = new AMDLoader();
@@ -88,7 +91,7 @@ export class AMDLoader {
      * // Map the resource to an external module path
      * loader.define('myResource', 'path/to/resource');
      */
-    define(name: string, module: string | ESM.Module, multiple: boolean = false): void {
+    define(name: string, module: string | ESM.Module, esm: boolean = false): void {
         if (typeof module == 'string') {
             this.#importMap.imports[name] = module;
         } else {
@@ -96,7 +99,7 @@ export class AMDLoader {
             // https://github.com/systemjs/systemjs/blob/6.15.1/docs/api.md#systemsetid-module---module
             const uri = `app:${name}`;
             this.#importMap.imports[name] = uri;
-            if (multiple || module[Symbol.toStringTag] === 'Module') {
+            if (esm || module[Symbol.toStringTag] === 'Module') {
                 this.#loader.set(uri, module);
             } else {
                 this.#loader.set(uri, {

--- a/tests/amd-loader.test.ts
+++ b/tests/amd-loader.test.ts
@@ -20,6 +20,22 @@ describe('AMDLoader', () => {
         expect(() => loader.define('testResourcePathNoError', '/path/to/module.js')).not.toThrow();
     });
 
+    it('should accept to redefine a resource (object)', async () => {
+        const loader = new AMDLoader();
+        loader.define('testResourceObject', { foo: 'bar' });
+        expect(await loader.load('testResourceObject')).toEqual({ foo: 'bar' });
+        loader.define('testResourceObject', { value: 42 });
+        expect(await loader.load('testResourceObject')).toEqual({ value: 42 });
+    });
+
+    it('should accept to redefine a resource (module path)', async () => {
+        const loader = new AMDLoader();
+        loader.define('testResourceObject', `${samplesHost}/resource.js`);
+        expect(await loader.load('testResourceObject')).toEqual({ foo: 'bar' });
+        loader.define('testResourceObject', `${samplesHost}/value.js`);
+        expect(await loader.load('testResourceObject')).toEqual({ value: 42 });
+    });
+
     it('should load a defined resource (object)', async () => {
         const loader = new AMDLoader();
         loader.define('testResourceObject', { foo: 'bar' });


### PR DESCRIPTION
This pull request addresses a possible race condition in the `PCILoader` class and introduces improvements to both the AMD module loader and PCI loader, along with new and updated tests to ensure correct behavior. The most significant changes include fixing concurrency issues in `PCILoader.load()`, updating the AMD loader API, and enhancing resource redefinition support.

### Race condition fix and loader improvements

* Fixed a possible race condition in `PCILoader.load()` by serializing concurrent load calls using an internal promise chain, ensuring that multiple calls resolve to the same registry getter instance. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL89-R90) [[3]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL100-R101) [[4]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL203-R226) [[5]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR245-R247) [[6]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R42-R57)

### AMDLoader API and resource management

* Updated the `AMDLoader.define()` method to accept an `esm` boolean parameter, clarifying ESM module handling and improving resource definition semantics. [[1]](diffhunk://#diff-37504447b2bc238a3e79192b14833b38e5de99b416a3dd2981f65c587c88e91bR79-R81) [[2]](diffhunk://#diff-37504447b2bc238a3e79192b14833b38e5de99b416a3dd2981f65c587c88e91bL91-R102)
* Added support for redefining resources in `AMDLoader`, allowing both object and module path resources to be redefined and loaded correctly. [[1]](diffhunk://#diff-8c8c4b8eff877c1a33218a820d235fe3491abd92cca30e9617dcd020c1aec91dR23-R38) [[2]](diffhunk://#diff-185bedfedc645527e535000a5d657fc23947953fa1cdca8b77927ec7496319fcR1-R3)

### PCI instance creation and error handling

* Improved PCI instance creation in `PCILoader.getInstance()` by accurately tracking elapsed time for timeouts and refining error messages for type mismatches. [[1]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cR338-R341) [[2]](diffhunk://#diff-c4bb3c4b27d7d1057b51f49c71b2752f93e57ab149de7bbbec659ece115c1c2cL348-R368) [[3]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27L106-R110)

### Test enhancements

* Added and updated tests for both loaders to verify resource redefinition, concurrent load behavior, and error handling, ensuring robust and predictable loader functionality. [[1]](diffhunk://#diff-8c8c4b8eff877c1a33218a820d235fe3491abd92cca30e9617dcd020c1aec91dR23-R38) [[2]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27R42-R57) [[3]](diffhunk://#diff-ea0f1ec70f73504da8086ed62672c0de1820ce62e6a405898c01632780f8eb27L106-R110)