### PR TITLE
test: add tests for handling loader failures in PCILoader and PCILoad…

### DIFF
--- a/tests/pci-loader-dev.test.ts
+++ b/tests/pci-loader-dev.test.ts
@@ -86,6 +86,28 @@ describe('PCILoaderDev', () => {
         expect(firstRegistry).toBe(secondRegistry);
     });
 
+    it('should call undefine on provided loader when previous importFlow failed', async () => {
+        const undefineSpy = vi.spyOn(AMDLoader.prototype, 'undefine');
+
+        // Make the first AMDLoader.load call reject to create a rejected importFlow
+        const loadSpy = vi.spyOn(AMDLoader.prototype, 'load').mockRejectedValueOnce(new Error('simulated fail'));
+
+        const loader = new PCILoaderDev(runtimeUrl, name);
+
+        await expect(loader.load()).rejects.toThrow('simulated fail');
+
+        // Second load should trigger the importFlow.catch branch which calls undefine
+        try {
+            await loader.load();
+        } catch {
+            // ignore second load result
+        }
+
+        expect(undefineSpy).toHaveBeenCalledWith(runtimeUrl);
+
+        loadSpy.mockRestore();
+    });
+
     it('should load and register a PCI', async () => {
         const loadSpy = vi.spyOn(AMDLoader.prototype, 'load');
         const registerSpy = vi.spyOn(PCIRegistry.prototype, 'register');

--- a/tests/pci-loader.test.ts
+++ b/tests/pci-loader.test.ts
@@ -57,6 +57,26 @@ describe('PCILoader', () => {
         expect(firstRegistry).toBe(secondRegistry);
     });
 
+    it('should gracefully proceed when previous importFlow failed with no loader', async () => {
+        // loader parameter is undefined for PCILoader; this ensures the catch block
+        // executes but the `if (loader)` branch is skipped.
+        const undefineSpy = vi.spyOn(AMDLoader.prototype, 'undefine');
+        const loadSpy = vi.spyOn(AMDLoader.prototype, 'load').mockRejectedValueOnce(new Error('fail'));
+
+        const loader = new PCILoader(url, name);
+        await expect(loader.load()).rejects.toThrow('fail');
+
+        // second invocation should trigger the catch from the rejected importFlow
+        try {
+            await loader.load();
+        } catch {
+            // ignore result
+        }
+
+        expect(undefineSpy).not.toHaveBeenCalled();
+        loadSpy.mockRestore();
+    });
+
     it('should load and register a PCI', async () => {
         const loadSpy = vi.spyOn(AMDLoader.prototype, 'load');
         const registerSpy = vi.spyOn(PCIRegistry.prototype, 'register');


### PR DESCRIPTION
This pull request adds new test cases to improve coverage of error handling in the `PCILoader` and `PCILoaderDev` classes. The new tests ensure that the behavior when previous `importFlow` calls fail is correct, specifically regarding the use of the `undefine` method in the AMD loader.

**Test coverage improvements:**

* Added a test to `PCILoaderDev` to verify that `AMDLoader.undefine` is called with the correct URL when a previous `importFlow` fails and a loader is provided.
* Added a test to `PCILoader` to verify that `AMDLoader.undefine` is not called when a previous `importFlow` fails and no loader is provided.…erDev