### PR TITLE
Feature/Update workflows and dependencies

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,8 +8,7 @@ on:
 
     workflow_run:
         workflows: ['Release']
-        types:
-            - completed
+        types: ['completed']
 
 permissions:
     contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
         branches: ['main']
         types: ['labeled']
 
+    workflow_dispatch:
+
 permissions:
     contents: write
     pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,8 @@ name: Release
 
 on:
     pull_request:
-        branches:
-            - main
-        types:
-            - labeled
+        branches: ['main']
+        types: ['labeled']
 
 permissions:
     contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
         branches:
             - main
         types:
-            - opened
             - labeled
 
 permissions:

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -2,14 +2,13 @@ name: Synchronize branches
 
 on:
     push:
-        branches: [main]
+        branches: ['main']
 
     workflow_dispatch:
 
     workflow_run:
         workflows: ['Release']
-        types:
-            - completed
+        types: ['completed']
 
 permissions:
     contents: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "prettier": "^3.8.1",
                 "prettier-plugin-svelte": "^3.5.1",
                 "sv-router": "^0.14.0",
-                "svelte": "^5.53.8",
+                "svelte": "^5.53.9",
                 "svelte-highlight": "^7.9.0",
                 "terser": "^5.46.0",
                 "typedoc": "^0.28.17",
@@ -4877,9 +4877,9 @@
             }
         },
         "node_modules/svelte": {
-            "version": "5.53.8",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.8.tgz",
-            "integrity": "sha512-UD++BnEc3PUFgjin381LiMHzDjT187Fy+KsPZxvaKrYPZqR0GQ/Ha8h7GDoegIF8tFl1uogoNUejKgcRk77T2Q==",
+            "version": "5.53.9",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.9.tgz",
+            "integrity": "sha512-MwDfWsN8qZzeP0jlQsWF4k/4B3csb3IbzCRggF+L/QqY7T8bbKvnChEo1cPZztF51HJQhilDbevWYl2LvXbquA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-svelte": "^3.5.1",
         "sv-router": "^0.14.0",
-        "svelte": "^5.53.8",
+        "svelte": "^5.53.9",
         "svelte-highlight": "^7.9.0",
         "terser": "^5.46.0",
         "typedoc": "^0.28.17",


### PR DESCRIPTION
This pull request makes several improvements to GitHub Actions workflows and updates a package dependency. The main changes streamline the workflow trigger configurations for clarity and conciseness, and update the `svelte` package to a newer version.

**GitHub Actions workflow improvements:**

* Updated the trigger configurations in `.github/workflows/release.yaml`, `.github/workflows/gh-pages.yaml`, and `.github/workflows/sync.yaml` to use a more concise array syntax for `branches` and `types`, and added `workflow_dispatch` to `release.yaml` for manual triggering. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL5-R8) [[2]](diffhunk://#diff-9f184e11981c71caabf911f9140c261b8d76c4fc9d623fae79063200ad744477L11-R11) [[3]](diffhunk://#diff-c0331e5bfbabc4af0a8a89a0bfd35411cf0626b31545e5440e5ccd931b23d845L5-R11)

**Dependency update:**

* Upgraded the `svelte` dependency version from `^5.53.8` to `^5.53.9` in `package.json` to ensure the latest bug fixes and improvements are included.